### PR TITLE
Give exitAction the QuitRole role.

### DIFF
--- a/code/MiamPlayer/mainwindow.ui
+++ b/code/MiamPlayer/mainwindow.ui
@@ -686,6 +686,8 @@
    <property name="text">
     <string>E&amp;xit</string>
    </property>
+   <property name="menuRole">
+   </property>
   </action>
   <action name="actionOpenFiles">
    <property name="text">

--- a/code/MiamPlayer/mainwindow.ui
+++ b/code/MiamPlayer/mainwindow.ui
@@ -687,6 +687,7 @@
     <string>E&amp;xit</string>
    </property>
    <property name="menuRole">
+    <enum>QAction::QuitRole</enum>
    </property>
   </action>
   <action name="actionOpenFiles">


### PR DESCRIPTION
Give exitAction the QuitRole, in order to move it to the application
menu.