### PR TITLE
Don't use title bar icon on Mac OS

### DIFF
--- a/code/MiamPlayer/dialogs/colordialog.cpp
+++ b/code/MiamPlayer/dialogs/colordialog.cpp
@@ -10,7 +10,9 @@ ColorDialog::ColorDialog(CustomizeThemeDialog *parent) :
 {
 	this->setAttribute(Qt::WA_DeleteOnClose);
 	this->setOptions(QColorDialog::NoButtons);
+#ifndef Q_OS_MAC
 	this->setWindowIcon(QIcon(":config/palette"));
+#endif
 	Qt::WindowFlags flags = this->windowFlags();
 	flags |= Qt::ForeignWindow;
 	this->setWindowFlags(flags);

--- a/code/MiamPlayer/mainwindow.cpp
+++ b/code/MiamPlayer/mainwindow.cpp
@@ -23,7 +23,9 @@ MainWindow::MainWindow(QWidget *parent) :
 	widgetSearchBar->setFrameBorder(false, false, true, false);
 
 	this->setAcceptDrops(true);
+#ifndef Q_OS_MAC
 	this->setWindowIcon(QIcon(":/icons/mp_win32"));
+#endif
 
 	// Special behaviour for media buttons
 	mediaButtons << skipBackwardButton << seekBackwardButton << playButton << stopButton


### PR DESCRIPTION
Don't use title bar icon on Mac OS because it doesn’t feel „native“.