### PR TITLE
qxt: Fix underlinking of X11 on Linux

### DIFF
--- a/src/core/qxt/qxt.pri
+++ b/src/core/qxt/qxt.pri
@@ -8,3 +8,7 @@ HEADERS += \
     qxt/qxtglobal.h \
     qxt/qxtglobalshortcut.h \
     qxt/qxtglobalshortcut_p.h
+
+unix:!macx {
+    LIBS += -lX11
+}


### PR DESCRIPTION
Underlinking issues would be raised when compiling with the `-Wl,--no-undefined` linker flag (which is part of the packaging policy for various Linux distros).

Errors without this patch:
```
/usr/bin/ld: release/.obj/qxtglobalshortcut_x11.o: in function `QxtGlobalShortcutPrivate::nativeKeycode(Qt::Key)':
/home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:190: undefined reference to `XStringToKeysym'
/usr/bin/ld: /home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:195: undefined reference to `XKeysymToKeycode'
/usr/bin/ld: release/.obj/qxtglobalshortcut_x11.o: in function `QxtGlobalShortcutPrivate::registerShortcut(unsigned int, unsigned int)':
/home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:70: undefined reference to `XSetErrorHandler'
/usr/bin/ld: /home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:107: undefined reference to `XGrabKey'
/usr/bin/ld: /home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:70: undefined reference to `XSetErrorHandler'
/usr/bin/ld: /home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:123: undefined reference to `XUngrabKey'
/usr/bin/ld: /home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:74: undefined reference to `XSetErrorHandler'
/usr/bin/ld: /home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:74: undefined reference to `XSetErrorHandler'
/usr/bin/ld: /home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:74: undefined reference to `XSetErrorHandler'
/usr/bin/ld: release/.obj/qxtglobalshortcut_x11.o: in function `QxtGlobalShortcutPrivate::unregisterShortcut(unsigned int, unsigned int)':
/home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:70: undefined reference to `XSetErrorHandler'
/usr/bin/ld: /home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:123: undefined reference to `XUngrabKey'
/usr/bin/ld: /home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:74: undefined reference to `XSetErrorHandler'
/usr/bin/ld: release/.obj/qxtglobalshortcut_x11.o: in function `QxtGlobalShortcutPrivate::registerShortcut(unsigned int, unsigned int) [clone .cold.25]':
/home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:74: undefined reference to `XSetErrorHandler'
/usr/bin/ld: /home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:74: undefined reference to `XSetErrorHandler'
/usr/bin/ld: release/.obj/qxtglobalshortcut_x11.o: in function `QxtGlobalShortcutPrivate::unregisterShortcut(unsigned int, unsigned int) [clone .cold.26]':
/home/akien/Mageia/Checkout/miam-player/BUILD/Miam-Player-0.9.0/src/core/qxt/qxtglobalshortcut_x11.cpp:74: undefined reference to `XSetErrorHandler'
```