### PR TITLE
acoustid: Use system headers for chromaprint on Unix

### DIFF
--- a/src/acoustid/acoustid.pro
+++ b/src/acoustid/acoustid.pro
@@ -1,6 +1,10 @@
 QT          += core gui multimedia network sql widgets
 TEMPLATE    = lib
-include(chromaprint/chromaprint.pri)
+
+# Use system headers on Unix
+win32 {
+    include(chromaprint/chromaprint.pri)
+}
 
 DEFINES += MIAMACOUSTID_LIBRARY
 

--- a/src/acoustid/qchromaprint.h
+++ b/src/acoustid/qchromaprint.h
@@ -1,7 +1,7 @@
 #ifndef QCHROMAPRINT_H
 #define QCHROMAPRINT_H
 
-#include <chromaprint/chromaprint.h>
+#include <chromaprint.h>
 
 #include <QObject>
 


### PR DESCRIPTION
Fixes #116 too.

If this fix is merged, #120 would not be needed, unless maybe building for Windows with MinGW.